### PR TITLE
feat:H1005-L2 - Payment capture and void for D-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">
 <i>Unified Payments Switch. Fast. Reliable. Affordable.</i>
 </p>
-
+ 
 <p align="center">
   <a href="https://github.com/juspay/hyperswitch/actions?query=workflow%3ACI+branch%3Amain">
     <img src="https://github.com/juspay/hyperswitch/workflows/CI/badge.svg" />

--- a/config/Development.toml
+++ b/config/Development.toml
@@ -43,7 +43,7 @@ locker_decryption_key2 = ""
 
 [connectors.supported]
 wallets = ["klarna","braintree","applepay"]
-cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline"]
+cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline", "dlocal"]
 
 [refund]
 max_attempts = 10
@@ -102,6 +102,9 @@ base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 [connectors.worldline]
 base_url = "https://eu.sandbox.api-ingenico.com/"
+
+[connectors.dlocal]
+base_url = ""
 
 [scheduler]
 stream = "SCHEDULER_STREAM"

--- a/config/Development.toml
+++ b/config/Development.toml
@@ -104,7 +104,7 @@ base_url = "https://apis.sandbox.globalpay.com/ucp/"
 base_url = "https://eu.sandbox.api-ingenico.com/"
 
 [connectors.dlocal]
-base_url = ""
+base_url = "https://sandbox.dlocal.com/"
 
 [scheduler]
 stream = "SCHEDULER_STREAM"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -152,6 +152,9 @@ base_url = "https://try.access.worldpay.com/"
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 # This data is used to call respective connectors for wallets and cards
+[connectors.dlocal]
+base_url = 
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
 cards = [

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -153,7 +153,7 @@ base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 # This data is used to call respective connectors for wallets and cards
 [connectors.dlocal]
-base_url = 
+base_url = "http://localhost:3002/"
 
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -105,9 +105,12 @@ base_url = "https://try.access.worldpay.com/"
 [connectors.globalpay]
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
+[connectors.dlocal]
+base_url = 
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
-cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "shift4", "cybersource", "worldpay", "globalpay", "fiserv"]
+cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "shift4", "cybersource", "worldpay", "globalpay", "fiserv", "dlocal"]
 
 
 [scheduler]

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -519,6 +519,7 @@ pub enum Connector {
     Cybersource,
     #[default]
     Dummy,
+	Dlocal,
     Fiserv,
     Globalpay,
     Klarna,

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -558,6 +558,7 @@ pub enum RoutableConnectors {
     Braintree,
     Checkout,
     Cybersource,
+    Dlocal,
     Fiserv,
     Globalpay,
     Klarna,

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -153,6 +153,7 @@ pub struct Connectors {
 
     // Keep this field separate from the remaining fields
     pub supported: SupportedConnectors,
+	pub dlocal: ConnectorParams,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/connector.rs
+++ b/crates/router/src/connector.rs
@@ -16,9 +16,12 @@ pub mod utils;
 pub mod worldline;
 pub mod worldpay;
 
+pub mod dlocal;
+
 pub use self::{
     aci::Aci, adyen::Adyen, applepay::Applepay, authorizedotnet::Authorizedotnet,
     braintree::Braintree, checkout::Checkout, cybersource::Cybersource, fiserv::Fiserv,
     globalpay::Globalpay, klarna::Klarna, payu::Payu, rapyd::Rapyd, shift4::Shift4, stripe::Stripe,
     worldline::Worldline, worldpay::Worldpay,
+dlocal::Dlocal,
 };

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -1,6 +1,6 @@
 mod transformers;
 
-use common_utils::{date_time, crypto::{SignMessage, self}};
+use common_utils::{date_time, crypto::{SignMessage, self}, ext_traits::Encode};
 use hex::encode;
 use time::{format_description::{self, well_known}, OffsetDateTime, PrimitiveDateTime, serde};
 use std::fmt::Debug;
@@ -92,7 +92,7 @@ impl ConnectorCommon for Dlocal {
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: dlocal::DlocalErrorResponse = res
             .response
-            .parse_struct("Shift4 ErrorResponse")
+            .parse_struct("Dlocal ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
@@ -146,9 +146,9 @@ impl
         Ok(format!(
             "{}{}{}{}",
             self.base_url(connectors),
-            "payments",
+            "payments/",
             cancelData.cancel_id,
-            "cancel"
+            "/cancel"
         ))
     }
 
@@ -198,6 +198,8 @@ impl
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        println!("logging response void");
+        println!("{:#?}",res.response);
         self.build_error_response(res)
     }
 }
@@ -334,6 +336,7 @@ impl
                 .headers(types::PaymentsCaptureType::get_headers(
                     self, req, connectors,
                 )?)
+                .body(types::PaymentsCaptureType::get_request_body(self, req)?)
                 .build(),
         ))
     }
@@ -361,6 +364,8 @@ impl
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        println!("logging response capture");
+        println!("{:#?}",res.response);
         self.build_error_response(res)
     }
 }

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -229,16 +229,21 @@ impl
     fn get_url(
         &self,
         _req: &types::PaymentsCaptureRouterData,
-        _connectors: &settings::Connectors,
+        connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        todo!()
+        Ok(format!(
+            "{}{}",
+            self.base_url(connectors),
+            "payments"
+        ))
     }
 
     fn get_request_body(
         &self,
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        todo!()
+        let dlocalReq = utils::Encode::<dlocal::DlocalPaymentsCaptureRequest>::convert_and_encode(req).change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(dlocalReq))
     }
 
     fn build_request(

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -48,8 +48,9 @@ where
                 ,dlocal_req.as_bytes())
                 .change_context(errors::ConnectorError::RequestEncodingFailed)
                 .attach_printable("Failed to sign the message")?;
-        let headers = vec![
-            (headers::AUTHORIZATION.to_string(), hex::encode(authz)),
+        let auth_string: String = format!("{}{}","V2-HMAC-SHA256, Signature: ".to_string(),hex::encode(authz));
+            let headers = vec![
+            (headers::AUTHORIZATION.to_string(), auth_string),
             (headers::X_LOGIN.to_string(), auth.xLogin.to_string()),
             (headers::X_TRANS_KEY.to_string(), auth.xTransKey.to_string()),
             (headers::X_VERSION.to_string(), "2.1".to_string()),
@@ -274,8 +275,8 @@ impl
         self.common_get_content_type()
     }
 
-    fn get_url(&self, _req: &types::PaymentsAuthorizeRouterData, _connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
-        todo!()
+    fn get_url(&self, _req: &types::PaymentsAuthorizeRouterData, connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        Ok(format!("{}{}", self.base_url(connectors), "secure_payments"))
     }
 
     fn get_request_body(&self, req: &types::PaymentsAuthorizeRouterData) -> CustomResult<Option<String>,errors::ConnectorError> {

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -1,0 +1,451 @@
+mod transformers;
+
+use std::fmt::Debug;
+use error_stack::{ResultExt, IntoReport};
+
+use crate::{
+    configs::settings,
+    utils::{self, BytesExt},
+    core::{
+        errors::{self, CustomResult},
+        payments,
+    },
+    headers, logger, services::{self, ConnectorIntegration},
+    types::{
+        self,
+        api::{self, ConnectorCommon, ConnectorCommonExt},
+        ErrorResponse, Response,
+    }
+};
+
+
+use transformers as dlocal;
+
+#[derive(Debug, Clone)]
+pub struct Dlocal;
+
+impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Dlocal
+where
+    Self: ConnectorIntegration<Flow, Request, Response>,{
+    fn build_headers(
+        &self,
+        _req: &types::RouterData<Flow, Request, Response>,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        todo!()
+    }
+}
+
+impl ConnectorCommon for Dlocal {
+    fn id(&self) -> &'static str {
+        "dlocal"
+    }
+
+    fn common_get_content_type(&self) -> &'static str {
+        todo!()
+        // Ex: "application/x-www-form-urlencoded"
+    }
+
+    fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {
+        connectors.dlocal.base_url.as_ref()
+    }
+
+    fn get_auth_header(&self, auth_type:&types::ConnectorAuthType)-> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
+        let auth: dlocal::DlocalAuthType = auth_type
+            .try_into()
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
+        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
+    }
+}
+
+impl api::Payment for Dlocal {}
+
+impl api::PreVerify for Dlocal {}
+impl
+    ConnectorIntegration<
+        api::Verify,
+        types::VerifyRequestData,
+        types::PaymentsResponseData,
+    > for Dlocal
+{
+}
+
+impl api::PaymentVoid for Dlocal {}
+
+impl
+    ConnectorIntegration<
+        api::Void,
+        types::PaymentsCancelData,
+        types::PaymentsResponseData,
+    > for Dlocal
+{}
+
+impl api::ConnectorAccessToken for Dlocal {}
+
+impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, types::AccessToken>
+    for Dlocal
+{
+}
+
+impl api::PaymentSync for Dlocal {}
+impl
+    ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
+    for Dlocal
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsSyncRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        todo!()
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
+        logger::debug!(payment_sync_response=?res);
+        let response: dlocal:: DlocalPaymentsResponse = res
+            .response
+            .parse_struct("dlocal PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+}
+
+
+impl api::PaymentCapture for Dlocal {}
+impl
+    ConnectorIntegration<
+        api::Capture,
+        types::PaymentsCaptureData,
+        types::PaymentsResponseData,
+    > for Dlocal
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsCaptureRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        todo!()
+    }
+
+    fn get_request_body(
+        &self,
+        _req: &types::PaymentsCaptureRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        todo!()
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsCaptureType::get_headers(
+                    self, req, connectors,
+                )?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCaptureRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
+        let response: dlocal::DlocalPaymentsResponse = res
+            .response
+            .parse_struct("Dlocal PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        logger::debug!(dlocalpayments_create_response=?response);
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::PaymentSession for Dlocal {}
+
+impl
+    ConnectorIntegration<
+        api::Session,
+        types::PaymentsSessionData,
+        types::PaymentsResponseData,
+    > for Dlocal
+{
+    //TODO: implement sessions flow
+}
+
+impl api::PaymentAuthorize for Dlocal {}
+
+impl
+    ConnectorIntegration<
+        api::Authorize,
+        types::PaymentsAuthorizeData,
+        types::PaymentsResponseData,
+    > for Dlocal {
+    fn get_headers(&self, req: &types::PaymentsAuthorizeRouterData, connectors: &settings::Connectors,) -> CustomResult<Vec<(String, String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(&self, _req: &types::PaymentsAuthorizeRouterData, _connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        todo!()
+    }
+
+    fn get_request_body(&self, req: &types::PaymentsAuthorizeRouterData) -> CustomResult<Option<String>,errors::ConnectorError> {
+        let dlocal_req =
+            utils::Encode::<dlocal::DlocalPaymentsRequest>::convert_and_encode(req).change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(dlocal_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsAuthorizeType::get_url(
+                    self, req, connectors,
+                )?)
+                .headers(types::PaymentsAuthorizeType::get_headers(
+                    self, req, connectors,
+                )?)
+                .body(types::PaymentsAuthorizeType::get_request_body(self, req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsAuthorizeRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsAuthorizeRouterData,errors::ConnectorError> {
+        let response: dlocal::DlocalPaymentsResponse = res.response.parse_struct("PaymentIntentResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        logger::debug!(dlocalpayments_create_response=?response);
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::Refund for Dlocal {}
+impl api::RefundExecute for Dlocal {}
+impl api::RefundSync for Dlocal {}
+
+impl
+    ConnectorIntegration<
+        api::Execute,
+        types::RefundsData,
+        types::RefundsResponseData,
+    > for Dlocal {
+    fn get_headers(&self, req: &types::RefundsRouterData<api::Execute>, connectors: &settings::Connectors,) -> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(&self, _req: &types::RefundsRouterData<api::Execute>, _connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        todo!()
+    }
+
+    fn get_request_body(&self, req: &types::RefundsRouterData<api::Execute>) -> CustomResult<Option<String>,errors::ConnectorError> {
+        let dlocal_req = utils::Encode::<dlocal::DlocalRefundRequest>::convert_and_encode(req).change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(dlocal_req))
+    }
+
+    fn build_request(&self, req: &types::RefundsRouterData<api::Execute>, connectors: &settings::Connectors,) -> CustomResult<Option<services::Request>,errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Post)
+            .url(&types::RefundExecuteType::get_url(self, req, connectors)?)
+            .headers(types::RefundExecuteType::get_headers(self, req, connectors)?)
+            .body(types::RefundExecuteType::get_request_body(self, req)?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundsRouterData<api::Execute>,
+        res: Response,
+    ) -> CustomResult<types::RefundsRouterData<api::Execute>,errors::ConnectorError> {
+        logger::debug!(target: "router::connector::dlocal", response=?res);
+        let response: dlocal::RefundResponse = res.response.parse_struct("dlocal RefundResponse").change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl
+    ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponseData> for Dlocal {
+    fn get_headers(&self, req: &types::RefundSyncRouterData,connectors: &settings::Connectors,) -> CustomResult<Vec<(String, String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(&self, _req: &types::RefundSyncRouterData,_connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        todo!()
+    }
+
+    fn build_request(
+        &self,
+        req: &types::RefundSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::RefundSyncType::get_url(self, req, connectors)?)
+                .headers(types::RefundSyncType::get_headers(self, req, connectors)?)
+                .body(types::RefundSyncType::get_request_body(self, req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::RefundSyncRouterData,errors::ConnectorError,> {
+        logger::debug!(target: "router::connector::dlocal", response=?res);
+        let response: dlocal::RefundResponse = res.response.parse_struct("dlocal RefundResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl api::IncomingWebhook for Dlocal {
+    fn get_webhook_object_reference_id(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+
+    fn get_webhook_event_type(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<api::IncomingWebhookEvent, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+
+    fn get_webhook_resource_object(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<serde_json::Value, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+}
+
+impl services::ConnectorRedirectResponse for Dlocal {
+    fn get_flow_type(
+        &self,
+        _query_params: &str,
+    ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
+        Ok(payments::CallConnectorAction::Trigger)
+    }
+}

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -2,9 +2,10 @@ mod transformers;
 
 use common_utils::{date_time, crypto::{SignMessage, self}};
 use hex::encode;
-use time::{format_description, OffsetDateTime};
+use time::{format_description, OffsetDateTime, PrimitiveDateTime};
 use std::fmt::Debug;
 use error_stack::{ResultExt, IntoReport};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     configs::settings,
@@ -40,7 +41,7 @@ where
             None => "".to_string()
         };
         #[serde(with = "common_utils::custom_serde::iso8601")]
-        let date = date_time::now();
+        let date:PrimitiveDateTime = date_time::now();
         let auth = dlocal::DlocalAuthType::try_from(&req.connector_auth_type)?;
         let reqForSign: String = format!("{}{}{}",auth.xLogin.to_string(),date.to_string(),dlocal_req);
         let authz =

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -73,6 +73,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for DlocalPaymentsRequest  {
                         None => "http://wwww.sandbox.juspay.in/hackathon/H1005".to_string()
                     }
                     };
+                println!("{:#?}",payment_request);
                 Ok(payment_request)
             }
             _ => Err(
@@ -112,7 +113,7 @@ impl TryFrom<&types::ConnectorAuthType> for DlocalAuthType  {
 // PaymentsResponse
 //TODO: Append the remaining status flags
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "UPPERCASE")]
 pub enum DlocalPaymentStatus {
     AUTHORIZED,
     PAID,

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -26,7 +26,7 @@ pub struct Card {
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 pub struct DlocalPaymentsRequest {
     pub amount: i64, //amount in cents, hence passed as integer
-    pub currency: enums::Currency ,
+    pub currency: enums::Currency,
     pub country: Option<String>,
     pub payment_method_id: String,
     pub payment_method_flow: String,
@@ -42,6 +42,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for DlocalPaymentsRequest  {
         match item.request.payment_method_data {
             api::PaymentMethod::Card(ref ccard) => {
                 let should_capture = matches!(
+                    item.request.capture_method,
                     Some(enums::CaptureMethod::Automatic) | None
                 );
                 let payment_request = Self {

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -1,0 +1,161 @@
+use serde::{Deserialize, Serialize};
+use crate::{core::errors,types::{self,api, storage::enums}};
+
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+pub struct Payer {
+    pub name : String
+    pub email: String
+    pub document: String
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Serialize)]
+pub struct Card {
+    pub holder_name: String,
+    pub number: String,
+    pub cvv: String,
+    pub expiration_month: i32,
+    pub expiration_year: i32,
+    pub capture: String,
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Serialize, Eq, PartialEq)]
+pub struct DlocalPaymentsRequest {
+    pub amount: i64, //amount in cents, hence passed as integer
+    pub currency: String,
+    pub country: String,
+    pub payment_method_id: String,
+    pub payment_method_flow: String,
+    pub payer: Payer,
+    pub card: Card,
+    pub order_id: String,
+    pub notification_url: String,
+}
+
+impl TryFrom<&types::PaymentsAuthorizeRouterData> for DlocalPaymentsRequest  {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(_item: &types::PaymentsAuthorizeRouterData) -> Result<Self,Self::Error> {
+        todo!()
+    }
+}
+
+//TODO: Fill the struct with respective fields
+// Auth Struct
+pub struct DlocalAuthType {
+    pub(super) api_key: String
+}
+
+impl TryFrom<&types::ConnectorAuthType> for DlocalAuthType  {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(_auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+// PaymentsResponse
+//TODO: Append the remaining status flags
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DlocalPaymentStatus {
+    Succeeded,
+    Failed,
+    #[default]
+    Processing,
+}
+
+impl From<DlocalPaymentStatus> for enums::AttemptStatus {
+    fn from(item: DlocalPaymentStatus) -> Self {
+        match item {
+            DlocalPaymentStatus::Succeeded => Self::Charged,
+            DlocalPaymentStatus::Failed => Self::Failure,
+            DlocalPaymentStatus::Processing => Self::Authorizing,
+        }
+    }
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DlocalPaymentsResponse {
+    status: DlocalPaymentStatus,
+    id: String,
+}
+
+impl<F,T> TryFrom<types::ResponseRouterData<F, DlocalPaymentsResponse, T, types::PaymentsResponseData>> for types::RouterData<F, T, types::PaymentsResponseData> {
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(item: types::ResponseRouterData<F, DlocalPaymentsResponse, T, types::PaymentsResponseData>) -> Result<Self,Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::from(item.response.status),
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),
+                redirection_data: None,
+                redirect: false,
+                mandate_reference: None,
+                connector_metadata: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+//TODO: Fill the struct with respective fields
+// REFUND :
+// Type definition for RefundRequest
+#[derive(Default, Debug, Serialize)]
+pub struct DlocalRefundRequest {}
+
+impl<F> TryFrom<&types::RefundsRouterData<F>> for DlocalRefundRequest {
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(_item: &types::RefundsRouterData<F>) -> Result<Self,Self::Error> {
+       todo!()
+    }
+}
+
+// Type definition for Refund Response
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Default, Deserialize, Clone)]
+pub enum RefundStatus {
+    Succeeded,
+    Failed,
+    #[default]
+    Processing,
+}
+
+impl From<RefundStatus> for enums::RefundStatus {
+    fn from(item: RefundStatus) -> Self {
+        match item {
+            RefundStatus::Succeeded => Self::Success,
+            RefundStatus::Failed => Self::Failure,
+            RefundStatus::Processing => Self::Pending,
+            //TODO: Review mapping
+        }
+    }
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct RefundResponse {
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::Execute, RefundResponse>>
+    for types::RefundsRouterData<api::Execute>
+{
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(
+        _item: types::RefundsResponseRouterData<api::Execute, RefundResponse>,
+    ) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>> for types::RefundsRouterData<api::RSync>
+{
+     type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(_item: types::RefundsResponseRouterData<api::RSync, RefundResponse>) -> Result<Self,Self::Error> {
+         todo!()
+     }
+ }
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct DlocalErrorResponse {}

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use crate::{core::errors,types::{self,api, storage::enums}};
-use self::{storage::enums as storage_enums};
 
 #[derive(Debug, Default, Eq, PartialEq, Serialize)]
 pub struct Payer {
@@ -23,7 +22,7 @@ pub struct Card {
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 pub struct DlocalPaymentsRequest {
     pub amount: i64, //amount in cents, hence passed as integer
-    pub currency: storage_enums::Currency,
+    pub currency: enums::Currency ,
     pub country: Option<String>,
     pub payment_method_id: String,
     pub payment_method_flow: String,
@@ -36,22 +35,27 @@ pub struct DlocalPaymentsRequest {
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for DlocalPaymentsRequest  {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self,Self::Error> {
-        let amount = item.request.amount,
-        let currency = item.request.currency,
-
+        todo!()
     }
 }
 
 //TODO: Fill the struct with respective fields
 // Auth Struct
 pub struct DlocalAuthType {
-    pub(super) api_key: String
+    pub(super) xLogin: String,
+    pub(super) xTransKey: String,
+    pub(super) secret : String,
 }
 
 impl TryFrom<&types::ConnectorAuthType> for DlocalAuthType  {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(_auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let types::ConnectorAuthType::SignatureKey { api_key , key1, api_secret} = auth_type {
+            Ok(Self { xLogin: (api_key.to_string()), xTransKey: (key1.to_string()), secret: (api_secret.to_string()) })
+        } else {
+            Err(errors::ConnectorError::FailedToObtainAuthType.into())
+        }
+
     }
 }
 // PaymentsResponse

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -134,9 +134,9 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for DlocalPaymentsCaptureRequest
         };
         Ok(Self {
             authorization_id: (item.request.connector_transaction_id.clone())
-            , amount: (amount_to_capture) // take amount_to_capture and
+            , amount: (amount_to_capture)
             , currency: (item.request.currency.to_string())
-            , order_id: (item.payment_id.clone()) // check the order id
+            , order_id: (item.payment_id.clone())
         })
     }
 }

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -104,6 +104,19 @@ impl TryFrom<&types::PaymentsSyncRouterData> for DlocalPaymentsSyncRequest  {
     }
 }
 
+pub struct DlocalPaymentsCancelRequest {
+    pub cancel_id: String ,
+}
+
+impl TryFrom<&types::PaymentsCancelRouterData> for DlocalPaymentsCancelRequest  {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::PaymentsCancelRouterData) -> Result<Self,Self::Error> {
+        Ok(Self {
+            cancel_id: (item.request.connector_transaction_id.clone()),
+        })
+    }
+}
+
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 pub struct DlocalPaymentsCaptureRequest {
     pub authorization_id: String ,
@@ -260,7 +273,30 @@ impl<F,T> TryFrom<types::ResponseRouterData<F, DlocalPaymentsCaptureResponse, T,
             ..item.data
         })
     }
-}//TODO: Fill the struct with respective fields
+}
+
+pub struct DlocalPaymentsCancelResponse {
+    status: DlocalPaymentStatus,
+    id: String,
+}
+impl<F,T> TryFrom<types::ResponseRouterData<F, DlocalPaymentsCancelResponse, T, types::PaymentsResponseData>> for types::RouterData<F, T, types::PaymentsResponseData> {
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(item: types::ResponseRouterData<F, DlocalPaymentsCancelResponse, T, types::PaymentsResponseData>) -> Result<Self,Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::from(item.response.status),
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),
+                redirection_data: None,
+                redirect: false,
+                mandate_reference: None,
+                connector_metadata: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+//TODO: Fill the struct with respective fields
 // REFUND :
 // Type definition for RefundRequest
 #[derive(Default, Debug, Serialize)]

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![recursion_limit = "256"]
 
 #[cfg(feature = "stripe")]

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -50,6 +50,10 @@ pub mod headers {
     pub const X_API_VERSION: &str = "X-ApiVersion";
     pub const DATE: &str = "Date";
     pub const X_MERCHANT_ID: &str = "X-Merchant-Id";
+    pub const X_LOGIN: &str = "X-Login";
+    pub const X_TRANS_KEY:&str = "X-Trans-Key";
+    pub const X_VERSION:&str = "X-Version";
+    pub const X_DATE:&str = "X-Date";
 }
 
 pub mod pii {

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -78,7 +78,7 @@ pub trait ConnectorIntegration<T, Req, Resp>: ConnectorIntegrationAny<T, Req, Re
 
     fn get_request_body(
         &self,
-        _req: &types::RouterData<T, Req, Resp>,
+        req: &types::RouterData<T, Req, Resp>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
         Ok(None)
     }
@@ -568,18 +568,18 @@ pub fn build_redirection_form(form: &RedirectForm) -> maud::Markup {
             head {
                 style {
                     r##"
-                    
-                    "## 
+
+                    "##
                 }
                 (PreEscaped(r##"
                 <style>
-                    #loader1 { 
+                    #loader1 {
                         width: 500px,
-                    } 
-                    @media max-width: 600px { 
-                        #loader1 { 
-                            width: 200px 
-                        } 
+                    }
+                    @media max-width: 600px {
+                        #loader1 {
+                            width: 200px
+                        }
                     }
                 </style>
                 "##))

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -176,7 +176,8 @@ impl ConnectorData {
             "stripe" => Ok(Box::new(&connector::Stripe)),
             "worldline" => Ok(Box::new(&connector::Worldline)),
             "worldpay" => Ok(Box::new(&connector::Worldpay)),
-            _ => Err(report!(errors::ConnectorError::InvalidConnectorName)
+            "dlocal" => Ok(Box::new(&connector::Dlocal)),
+			_ => Err(report!(errors::ConnectorError::InvalidConnectorName)
                 .attach_printable(format!("invalid connector name: {connector_name}")))
             .change_context(errors::ApiErrorResponse::InternalServerError),
         }

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -23,7 +23,7 @@ impl ConnectorAuthentication {
     pub(crate) fn new() -> Self {
         #[allow(clippy::expect_used)]
         toml::from_str(
-            &std::fs::read_to_string("tests/connectors/auth.toml")
+            &std::fs::read_to_string("tests/connectors/sample_auth.toml")
                 .expect("connector authentication config file not found"),
         )
         .expect("Failed to read connector authentication config file")

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct ConnectorAuthentication {
+	pub dlocal: Option<HeaderKey>,
     pub aci: Option<BodyKey>,
     pub adyen: Option<BodyKey>,
     pub authorizedotnet: Option<BodyKey>,

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct ConnectorAuthentication {
-	pub dlocal: Option<HeaderKey>,
+	pub dlocal: Option<SignatureKey>,
     pub aci: Option<BodyKey>,
     pub adyen: Option<BodyKey>,
     pub authorizedotnet: Option<BodyKey>,

--- a/crates/router/tests/connectors/dlocal.rs
+++ b/crates/router/tests/connectors/dlocal.rs
@@ -1,0 +1,438 @@
+use masking::Secret;
+use router::types::{self, api, storage::enums};
+
+use crate::{
+    connector_auth,
+    utils::{self, ConnectorActions},
+};
+
+#[derive(Clone, Copy)]
+struct DlocalTest;
+impl ConnectorActions for DlocalTest {}
+impl utils::Connector for DlocalTest {
+    fn get_data(&self) -> types::api::ConnectorData {
+        use router::connector::Dlocal;
+        types::api::ConnectorData {
+            connector: Box::new(&Dlocal),
+            connector_name: types::Connector::Dlocal,
+            get_token: types::api::GetToken::Connector,
+        }
+    }
+
+    fn get_auth_token(&self) -> types::ConnectorAuthType {
+        types::ConnectorAuthType::from(
+            connector_auth::ConnectorAuthentication::new()
+                .dlocal
+                .expect("Missing connector authentication configuration"),
+        )
+    }
+
+    fn get_name(&self) -> String {
+        "dlocal".to_string()
+    }
+}
+
+static CONNECTOR: DlocalTest = DlocalTest {};
+
+// Cards Positive Tests
+// Creates a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_only_authorize_payment() {
+    let response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized);
+}
+
+// Captures a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(None, None, None)
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Partially captures a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(
+            None,
+            Some(types::PaymentsCaptureData {
+                amount_to_capture: Some(50),
+                ..utils::PaymentCaptureType::default().0
+            }),
+            None,
+        )
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_authorized_payment() {
+    let authorize_response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Authorized,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .expect("PSync response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized,);
+}
+
+// Voids a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_void_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_void_payment(
+            None,
+            Some(types::PaymentsCancelData {
+                connector_transaction_id: String::from(""),
+                cancellation_reason: Some("requested_by_customer".to_string()),
+            }),
+            None,
+        )
+        .await
+        .expect("Void payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Voided);
+}
+
+// Refunds a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(
+            None,
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Synchronizes a refund using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_manually_captured_refund() {
+    let refund_response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_make_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_auto_captured_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Charged,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status, enums::AttemptStatus::Charged,);
+}
+
+// Refunds a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_auto_captured_payment() {
+    let response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_refund_succeeded_payment() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        refund_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates multiple refunds against a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_succeeded_payment_multiple_times() {
+    CONNECTOR
+        .make_payment_and_multiple_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await;
+}
+
+// Synchronizes a refund using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_refund() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Cards Negative scenerios
+// Creates a payment with incorrect card number.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new("1234567891011".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card number is incorrect.".to_string(),
+    );
+}
+
+// Creates a payment with empty card number.
+#[actix_web::test]
+async fn should_fail_payment_for_empty_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new(String::from("")),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let x = response.response.unwrap_err();
+    assert_eq!(
+        x.message,
+        "You passed an empty string for 'payment_method_data[card][number]'.",
+    );
+}
+
+// Creates a payment with incorrect CVC.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_cvc() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_cvc: Secret::new("12345".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's security code is invalid.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry month.
+#[actix_web::test]
+async fn should_fail_payment_for_invalid_exp_month() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_month: Secret::new("20".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's expiration month is invalid.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry year.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_expiry_year() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_year: Secret::new("2000".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's expiration year is invalid.".to_string(),
+    );
+}
+
+// Voids a payment using automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_fail_void_payment_for_auto_capture() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let void_response = CONNECTOR
+        .void_payment(txn_id.unwrap(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        void_response.response.unwrap_err().message,
+        "You cannot cancel this PaymentIntent because it has a status of succeeded."
+    );
+}
+
+// Captures a payment using invalid connector payment id.
+#[actix_web::test]
+async fn should_fail_capture_for_invalid_payment() {
+    let capture_response = CONNECTOR
+        .capture_payment("123456789".to_string(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        capture_response.response.unwrap_err().message,
+        String::from("No such payment_intent: '123456789'")
+    );
+}
+
+// Refunds a payment with refund amount higher than payment amount.
+#[actix_web::test]
+async fn should_fail_for_refund_amount_higher_than_payment_amount() {
+    let response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 150,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Refund amount (₹1.50) is greater than charge amount (₹1.00)",
+    );
+}
+
+// Connector dependent test cases goes here
+
+// [#478]: add unit tests for non 3DS, wallets & webhooks in connector tests

--- a/crates/router/tests/connectors/dlocal.rs
+++ b/crates/router/tests/connectors/dlocal.rs
@@ -94,6 +94,8 @@ async fn should_sync_authorized_payment() {
         )
         .await
         .expect("PSync response");
+    println!("response from authorized payment");
+    println!("{}",response.status);
     assert_eq!(response.status, enums::AttemptStatus::Authorized,);
 }
 
@@ -279,7 +281,7 @@ async fn should_fail_payment_for_incorrect_card_number() {
         .make_payment(
             Some(types::PaymentsAuthorizeData {
                 payment_method_data: types::api::PaymentMethod::Card(api::Card {
-                    card_number: Secret::new("1234567891011".to_string()),
+                    card_number: Secret::new("1891011".to_string()),
                     ..utils::CCardType::default().0
                 }),
                 ..utils::PaymentAuthorizeType::default().0
@@ -288,9 +290,14 @@ async fn should_fail_payment_for_incorrect_card_number() {
         )
         .await
         .unwrap();
+    let x = response.response.unwrap_err();
     assert_eq!(
-        response.response.unwrap_err().message,
-        "Your card number is incorrect.".to_string(),
+        x.message,
+        "Invalid parameter",
+    );
+    assert_eq!(
+        x.reason,
+        Some("card.number".to_string())
     );
 }
 
@@ -313,7 +320,11 @@ async fn should_fail_payment_for_empty_card_number() {
     let x = response.response.unwrap_err();
     assert_eq!(
         x.message,
-        "You passed an empty string for 'payment_method_data[card][number]'.",
+        "Invalid parameter",
+    );
+    assert_eq!(
+        x.reason,
+        Some("card.number".to_string())
     );
 }
 
@@ -324,7 +335,7 @@ async fn should_fail_payment_for_incorrect_cvc() {
         .make_payment(
             Some(types::PaymentsAuthorizeData {
                 payment_method_data: types::api::PaymentMethod::Card(api::Card {
-                    card_cvc: Secret::new("12345".to_string()),
+                    card_cvc: Secret::new("1ad2345".to_string()),
                     ..utils::CCardType::default().0
                 }),
                 ..utils::PaymentAuthorizeType::default().0
@@ -333,9 +344,14 @@ async fn should_fail_payment_for_incorrect_cvc() {
         )
         .await
         .unwrap();
+    let x = response.response.unwrap_err();
     assert_eq!(
-        response.response.unwrap_err().message,
-        "Your card's security code is invalid.".to_string(),
+        x.message,
+        "Invalid parameter",
+    );
+    assert_eq!(
+        x.reason,
+        Some("card.cvv".to_string())
     );
 }
 
@@ -346,7 +362,7 @@ async fn should_fail_payment_for_invalid_exp_month() {
         .make_payment(
             Some(types::PaymentsAuthorizeData {
                 payment_method_data: types::api::PaymentMethod::Card(api::Card {
-                    card_exp_month: Secret::new("20".to_string()),
+                    card_exp_month: Secret::new("201".to_string()),
                     ..utils::CCardType::default().0
                 }),
                 ..utils::PaymentAuthorizeType::default().0
@@ -355,9 +371,14 @@ async fn should_fail_payment_for_invalid_exp_month() {
         )
         .await
         .unwrap();
+    let x = response.response.unwrap_err();
     assert_eq!(
-        response.response.unwrap_err().message,
-        "Your card's expiration month is invalid.".to_string(),
+        x.message,
+        "Invalid parameter",
+    );
+    assert_eq!(
+        x.reason,
+        Some("card.expiration_month".to_string())
     );
 }
 
@@ -368,7 +389,7 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
         .make_payment(
             Some(types::PaymentsAuthorizeData {
                 payment_method_data: types::api::PaymentMethod::Card(api::Card {
-                    card_exp_year: Secret::new("2000".to_string()),
+                    card_exp_year: Secret::new("20001".to_string()),
                     ..utils::CCardType::default().0
                 }),
                 ..utils::PaymentAuthorizeType::default().0
@@ -377,9 +398,14 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
         )
         .await
         .unwrap();
+    let x = response.response.unwrap_err();
     assert_eq!(
-        response.response.unwrap_err().message,
-        "Your card's expiration year is invalid.".to_string(),
+        x.message,
+        "Invalid parameter",
+    );
+    assert_eq!(
+        x.reason,
+        Some("card.expiration_year".to_string())
     );
 }
 

--- a/crates/router/tests/connectors/dlocal.rs
+++ b/crates/router/tests/connectors/dlocal.rs
@@ -420,9 +420,10 @@ async fn should_fail_void_payment_for_auto_capture() {
         .void_payment(txn_id.unwrap(), None, None)
         .await
         .unwrap();
+    let x = void_response.response.unwrap_err();
     assert_eq!(
-        void_response.response.unwrap_err().message,
-        "You cannot cancel this PaymentIntent because it has a status of succeeded."
+        x.code,
+        "5021",
     );
 }
 
@@ -430,12 +431,13 @@ async fn should_fail_void_payment_for_auto_capture() {
 #[actix_web::test]
 async fn should_fail_capture_for_invalid_payment() {
     let capture_response = CONNECTOR
-        .capture_payment("123456789".to_string(), None, None)
+        .capture_payment("123456sdf789".to_string(), None, None)
         .await
         .unwrap();
+    let x = capture_response.response.unwrap_err();
     assert_eq!(
-        capture_response.response.unwrap_err().message,
-        String::from("No such payment_intent: '123456789'")
+        x.code,
+        "3003",
     );
 }
 

--- a/crates/router/tests/connectors/main.rs
+++ b/crates/router/tests/connectors/main.rs
@@ -12,6 +12,7 @@ mod payu;
 mod rapyd;
 mod shift4;
 mod stripe;
+mod dlocal;
 mod utils;
 mod worldline;
 mod worldpay;

--- a/crates/router/tests/connectors/sample_auth.toml
+++ b/crates/router/tests/connectors/sample_auth.toml
@@ -48,3 +48,8 @@ api_secret = "MySecretKey"
 key1 = "Merchant Id"
 api_key = "API Key"
 api_secret = "API Secret Key"
+
+[dlocal]
+key1 = "t3Xx74amrn"
+api_key = "pXnn2rwEvs"
+api_secret = "U3MeMGoGLUN32BlCXJLdAheBT6xP6o9tA"

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -84,6 +84,9 @@ base_url = "https://apple-pay-gateway.apple.com/"
 [connectors.klarna]
 base_url = "https://api-na.playground.klarna.com/"
 
+[connectors.dlocal]
+base_url = 
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
-cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "cybersource", "shift4", "worldpay", "globalpay"]
+cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "cybersource", "shift4", "worldpay", "globalpay", "dlocal"]

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -85,7 +85,7 @@ base_url = "https://apple-pay-gateway.apple.com/"
 base_url = "https://api-na.playground.klarna.com/"
 
 [connectors.dlocal]
-base_url = 
+base_url = "http://localhost:3002/"
 
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Added Capture and void methods


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Integration of D-Local-->


## How did you test it?
<!--
Used test scripts. attaching ss
<img width="622" alt="Screenshot 2023-02-12 at 2 43 56 AM" src="https://user-images.githubusercontent.com/17565447/218281610-da625d02-54f5-4963-9b50-24743eba51c5.png">


-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
